### PR TITLE
Properly set the currently running task.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 next
 ====
 
-nothing yet
+* Properly set the ``current_task`` when running Batch tasks.
 
 0.2 2018-04-20
 ==============


### PR DESCRIPTION
This implements more of the `celery.app.trace.trace_task` (which is built from `build_tracer`). The additions allow `current_task` to be accessed properly for a `Batches` task. See https://github.com/celery/celery/blob/v4.1.0/celery/app/trace.py#L334-L483 for the standard Celery version.