### PR TITLE
Ensure Kombu 4.2.0 is not used with Celery 4.0.x.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,9 @@ envlist =
 deps=
     -r{toxinidir}/requirements/test.txt
     celery40: celery>=4.0,<4.1
+    # Kombu 4.2.0 is incompatible with Celery 4.0.x. It is compatible with
+    # Celery 4.1.1 and 4.2.x.
+    celery40: kombu<4.2
     celery41: celery>=4.1,<4.2
     celerymaster: https://codeload.github.com/celery/celery/zip/master
 sitepackages = False


### PR DESCRIPTION
Kombu 4.2.0 was released which is incompatible with Celery < 4.1.1. This gets the build passing again with Celery 4.0.x.