### PR TITLE
Call the success signal.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ next
 ====
 
 * Properly set the ``current_task`` when running Batch tasks.
+* Call the success signal after a successful run of the Batch task.
 
 0.2 2018-04-20
 ==============

--- a/celery_batches/__init__.py
+++ b/celery_batches/__init__.py
@@ -132,6 +132,7 @@ def consume_queue(queue):
 
 send_prerun = signals.task_prerun.send
 send_postrun = signals.task_postrun.send
+send_success = signals.task_success.send
 SUCCESS = states.SUCCESS
 FAILURE = states.FAILURE
 
@@ -146,6 +147,7 @@ def apply_batches_task(task, args, loglevel, logfile):
 
     prerun_receivers = signals.task_prerun.receivers
     postrun_receivers = signals.task_postrun.receivers
+    success_receivers = signals.task_success.receivers
 
     # Corresponds to multiple requests, so generate a new UUID.
     task_id = uuid()
@@ -154,19 +156,23 @@ def apply_batches_task(task, args, loglevel, logfile):
     task_request = Context(loglevel=loglevel, logfile=logfile)
     push_request(task_request)
 
-    # -*- PRE -*-
-    if prerun_receivers:
-        send_prerun(sender=task, task_id=task_id, task=task,
-                    args=args, kwargs={})
-
-    # -*- TRACE -*-
     try:
-        result = task(*args)
-        state = SUCCESS
-    except Exception as exc:
-        result = None
-        state = FAILURE
-        logger.error('Error: %r', exc, exc_info=True)
+        # -*- PRE -*-
+        if prerun_receivers:
+            send_prerun(sender=task, task_id=task_id, task=task,
+                        args=args, kwargs={})
+
+        # -*- TRACE -*-
+        try:
+            result = task(*args)
+            state = SUCCESS
+        except Exception as exc:
+            result = None
+            state = FAILURE
+            logger.error('Error: %r', exc, exc_info=True)
+        else:
+            if success_receivers:
+                send_success(sender=task, result=result)
     finally:
         try:
             if postrun_receivers:

--- a/celery_batches/__init__.py
+++ b/celery_batches/__init__.py
@@ -3,7 +3,15 @@
 celery_batches
 ==============
 
-Experimental task class that buffers messages and processes them as a list.
+Experimental task class that buffers messages and processes them as a list. Task
+requests are buffered in memory (on a worker) until either the flush count or
+flush interval is reached. Once the requests are flushed, they are sent to the
+task as a list of :class:`~celery_batches.SimpleRequest` instances.
+
+It is possible to return a result for each task request by calling
+``mark_as_done`` on your results backend. Returning a value from the Batch task
+call is only used to provide values to signals and does not populate into the
+results backend.
 
 .. warning::
 

--- a/t/integration/test_batches.py
+++ b/t/integration/test_batches.py
@@ -95,7 +95,7 @@ def test_signals(celery_app, celery_worker):
         (signals.task_postrun, 1),
         # Other task signals are not implemented.
         (signals.task_retry, 0),
-        (signals.task_success, 0),
+        (signals.task_success, 1),
         (signals.task_failure, 0),
         (signals.task_revoked, 0),
         (signals.task_unknown, 0),


### PR DESCRIPTION
This calls the celery success signal after the task has run. This uses the result of the celery batches call, which isn't really used anywhere else (it isn't returned to any `AsyncResult` since no particular result exists for this task run).

This also re-arranges some of the try-excepts to ensure that the post-run signal runs even if an exception happens in the success signal.