### PR TITLE
Override `Task.apply()` to support eager running of Batches

### DIFF
--- a/celery_batches/__init__.py
+++ b/celery_batches/__init__.py
@@ -98,9 +98,8 @@ from itertools import count
 
 from celery import signals, states
 from celery._state import _task_stack
-from celery.app.task import Context
+from celery.app.task import Context, Task
 from celery.five import Empty, Queue
-from celery.task import Task
 from celery.utils import noop
 from celery.utils.log import get_logger
 from celery.worker.request import Request
@@ -288,6 +287,18 @@ class Batches(Task):
                 flush_buffer()
 
         return task_message_handler
+
+    def apply(self, args=None, kwargs=None, *_args, **_kwargs):
+        request = SimpleRequest(
+            id=_kwargs.get("task_id", uuid()),
+            name="batch application",
+            args=args or (),
+            kwargs=kwargs or {},
+            delivery_info=None,
+            hostname="localhost",
+        )
+
+        return super().apply(([request],), {}, *_args, **_kwargs)
 
     def flush(self, requests):
         return self.apply_buffer(requests, ([SimpleRequest.from_request(r)

--- a/t/integration/test_batches.py
+++ b/t/integration/test_batches.py
@@ -47,6 +47,19 @@ def _wait_for_ping(ping_task_timeout=10.0):
         assert ping.delay().get(timeout=ping_task_timeout) == 'pong'
 
 
+def test_always_eager():
+    """The batch task runs immediately, in the same thread."""
+    app = add._get_app()
+    task_always_eager = app.conf.task_always_eager
+    app.conf["task_always_eager"] = True
+
+    add.delay(1)
+
+    app.conf["task_always_eager"] = task_always_eager
+
+    assert Results().get() == 1
+
+
 def test_flush_interval(celery_worker):
     """The batch task runs after the flush interval has elapsed."""
     add.delay(1)


### PR DESCRIPTION
Prior to this change, eager running of batches caused errors whereby
the batched task was passed the args and kwargs directly, rather than
wrapping them as a request, when the following was called:
`.apply_async(args, kwargs, *_args, **_kwargs)`

This change updates the minumum viable version of celery, and overrides
the new `Task.apply()` method to pass the request wrapped in a
`SimpleRequest` and a `list` to the underlying function when in eager mode.