### PR TITLE
Minor clean-ups to eager code path (PR #16)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ next
 
 * Properly set the ``current_task`` when running Batch tasks.
 * Call the success signal after a successful run of the Batch task.
+* Support running tasks eagerly via the ``Task.apply()`` method. This causes
+  the task to execute with a batch of a single item.
 
 0.2 2018-04-20
 ==============

--- a/celery_batches/__init__.py
+++ b/celery_batches/__init__.py
@@ -306,7 +306,7 @@ class Batches(Task):
             hostname="localhost",
         )
 
-        return super().apply(([request],), {}, *_args, **_kwargs)
+        return super(Batches, self).apply(([request],), {}, *_args, **_kwargs)
 
     def flush(self, requests):
         return self.apply_buffer(requests, ([SimpleRequest.from_request(r)

--- a/celery_batches/__init__.py
+++ b/celery_batches/__init__.py
@@ -289,9 +289,17 @@ class Batches(Task):
         return task_message_handler
 
     def apply(self, args=None, kwargs=None, *_args, **_kwargs):
+        """
+        Execute this task locally as a batch of size 1, by blocking until the task returns.
+
+        Arguments:
+            args (Tuple): positional arguments passed on to the task.
+        Returns:
+            celery.result.EagerResult: pre-evaluated result.
+        """
         request = SimpleRequest(
             id=_kwargs.get("task_id", uuid()),
-            name="batch application",
+            name="batch request",
             args=args or (),
             kwargs=kwargs or {},
             delivery_info=None,

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -38,6 +38,7 @@ def add(requests):
         result += request.args[0]
 
     Results().set(result)
+    return result
 
 
 @shared_task(base=Batches, flush_every=2, flush_interval=1)

--- a/t/integration/test_batches.py
+++ b/t/integration/test_batches.py
@@ -53,10 +53,12 @@ def test_always_eager():
     task_always_eager = app.conf.task_always_eager
     app.conf["task_always_eager"] = True
 
-    add.delay(1)
+    result = add.delay(1)
 
     app.conf["task_always_eager"] = task_always_eager
 
+    # An EagerResult that resolve to 1 should be returned.
+    assert result.get() == 1
     assert Results().get() == 1
 
 

--- a/t/integration/test_batches.py
+++ b/t/integration/test_batches.py
@@ -62,6 +62,15 @@ def test_always_eager():
     assert Results().get() == 1
 
 
+def test_apply():
+    """The batch task runs immediately, in the same thread."""
+    result = add.apply(args=(1, ))
+
+    # An EagerResult that resolve to 1 should be returned.
+    assert result.get() == 1
+    assert Results().get() == 1
+
+
 def test_flush_interval(celery_worker):
     """The batch task runs after the flush interval has elapsed."""
     add.delay(1)


### PR DESCRIPTION
This has a few minor changes from #16, partially taken from 80609f8917e95f0e88c4d0de4f313148b27bb96c.

* Update the docstring.
* Refine the tests a bit.
* Add back support for Python 2.