### PR TITLE
Bump Python and Celery versions for tox/Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ matrix:
       env: CELERY_VERSION=42
   allow_failures:
     - env: CELERY_VERSION=master
+    - python: pypy
 before_install:
   # If TOXENV is not set, build it from the Python and Celery versions.
   - if [[ -v CELERY_VERSION ]]; then export TOXENV=${TRAVIS_PYTHON_VERSION}-celery${CELERY_VERSION}; fi; env

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,20 @@ matrix:
     - python: '3.6'
       env: TOXENV=flake8
       stage: lint
+  # Celery 4.3 added support for Python >= 3.7.
+  exclude:
+    - python: '3.7'
+      env: CELERY_VERSION=40
+    - python: '3.7'
+      env: CELERY_VERSION=41
+    - python: '3.7'
+      env: CELERY_VERSION=42
+    - python: '3.8'
+      env: CELERY_VERSION=40
+    - python: '3.8'
+      env: CELERY_VERSION=41
+    - python: '3.8'
+      env: CELERY_VERSION=42
   allow_failures:
     - env: CELERY_VERSION=master
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ dist: trusty
 cache: pip
 python:
   - '2.7'
-  - '3.4'
   - '3.5'
   - '3.6'
+  - '3.7'
+  - '3.8'
   - 'pypy'
   - 'pypy3'
 os:
@@ -18,6 +19,8 @@ env:
   - CELERY_VERSION=40
   - CELERY_VERSION=41
   - CELERY_VERSION=42
+  - CELERY_VERSION=43
+  - CELERY_VERSION=44
   - CELERY_VERSION=master
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
-sudo: required
-dist: trusty
+dist: bionic
 cache: pip
 python:
   - '2.7'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ next
 * Call the success signal after a successful run of the Batch task.
 * Support running tasks eagerly via the ``Task.apply()`` method. This causes
   the task to execute with a batch of a single item.
+* Officially support Python 3.7 and 3.8. Drop support for Python 3.4.
+* Officially support Celery 4.3 and 4.4.
 
 0.2 2018-04-20
 ==============

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps=
     celery41: celery>=4.1,<4.2
     celery42: celery>=4.2,<4.3
     celery43: celery>=4.3,<4.4
+    celery44: celery>=4.4,<4.5
     celerymaster: https://codeload.github.com/celery/celery/zip/master
 
     flake8: -r{toxinidir}/requirements/pkgutils.txt
@@ -23,10 +24,10 @@ commands =
     coverage html
 basepython =
     2.7: python2.7
-    3.4: python3.4
     3.5: python3.5
     3.6: python3.6
     3.7: python3.7
+    3.8: python3.8
     pypy: pypy
     pypy3: pypy3
     flake8: python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 envlist =
-    {2.7,pypy,3.4,3.5,3.6,3.7,pypy3}-celery{40,41,42,43,master}
+    {2.7,pypy,3.4,3.5,3.6,pypy3}-celery{40,41,42}
+    # Celery 4.3 adds support for Python 3.7 and higher.
+    {3.7,3.8}-celery{43,44,master}
     flake8
 
 [testenv]


### PR DESCRIPTION
Adds Python 3.7/3.8 to the support matrix. Removes 3.4.

Adds Celery 4.3 and 4.4 to the support matrix.